### PR TITLE
Fix gen script to account for short-hand (relative) internal links on readme

### DIFF
--- a/cmds/generate_docs/index.js
+++ b/cmds/generate_docs/index.js
@@ -40,12 +40,22 @@ const extractInfo = data => {
 };
 
 const toMd = info => `---\n${Object.entries(info).map(([key, data]) => `${key}: ${data}`).join('\n')}\n---\n`;
+
 const externalLink = url => url.match(/^[a-zA-Z]*:\/\//);
 const isDocLink = url => url.startsWith('/doc/') && url.split('#')[0].endsWith('.md');
 const isShortDocLink = url => url.match(/^[a-zA-Z0-9_-]*\.md/);
-const replaceShortLink = (g1, g2) => isShortDocLink(g2) ? `[${g1}](/docs/${g2})` : `[${g1}](https://github.com/flame-engine/flame/blob/master/${g2.replace(/^\//, '')})`;
-const replaceInternalLink = (g1, g2) => isDocLink(g2) ? `[${g1}](${g2.replace('/doc/', '/docs/')})` : replaceShortLink(g1, g2);
-const replaceLinks = md => md.replace(/\[([^[\]]*)\]\(([^()]*)\)/g, (_, g1, g2) => externalLink(g2) ? `[${g1}](${g2})` : replaceInternalLink(g1, g2));
+
+const replaceLinks = md => md.replace(/\[([^[\]]*)\]\(([^()]*)\)/g, (_, g1, g2) => {
+  if (externalLink(g2)) {
+    return `[${g1}](${g2})`;
+  } else if (isDocLink(g2)) {
+    return `[${g1}](${g2.replace('/doc/', '/docs/')})`;
+  } else if (isShortDocLink(g2)) {
+    return `[${g1}](/docs/${g2})`;
+  } else {
+    return `[${g1}](https://github.com/flame-engine/flame/blob/master/${g2.replace(/^\//, '')})`;
+  }
+});
 const enhanceMd = (info, file) => `${toMd(info)}\n${replaceLinks(file)}`;
 
 const links = data.flatMap(e => [e, ...(e.children || [])]).filter(e => e.link);

--- a/cmds/generate_docs/index.js
+++ b/cmds/generate_docs/index.js
@@ -42,7 +42,9 @@ const extractInfo = data => {
 const toMd = info => `---\n${Object.entries(info).map(([key, data]) => `${key}: ${data}`).join('\n')}\n---\n`;
 const externalLink = url => url.match(/^[a-zA-Z]*:\/\//);
 const isDocLink = url => url.startsWith('/doc/') && url.split('#')[0].endsWith('.md');
-const replaceInternalLink = (g1, g2) => isDocLink(g2) ? `[${g1}](${g2.replace('/doc/', '/docs/')})` : `[${g1}](https://github.com/flame-engine/flame/blob/master/${g2.replace(/^\//, '')})`;
+const isShortDocLink = url => url.match(/^[a-zA-Z0-9_-]*\.md/);
+const replaceShortLink = (g1, g2) => isShortDocLink(g2) ? `[${g1}](/docs/${g2})` : `[${g1}](https://github.com/flame-engine/flame/blob/master/${g2.replace(/^\//, '')})`;
+const replaceInternalLink = (g1, g2) => isDocLink(g2) ? `[${g1}](${g2.replace('/doc/', '/docs/')})` : replaceShortLink(g1, g2);
 const replaceLinks = md => md.replace(/\[([^[\]]*)\]\(([^()]*)\)/g, (_, g1, g2) => externalLink(g2) ? `[${g1}](${g2})` : replaceInternalLink(g1, g2));
 const enhanceMd = (info, file) => `${toMd(info)}\n${replaceLinks(file)}`;
 


### PR DESCRIPTION
Fixing https://github.com/flame-engine/flame-engine-site/issues/3

Basically we account for absolute internal links on the docs (/doc/xxx) but not relative links. Relative links are only used in the README.md file in order to build the menu (so I didn't want to change them on flame side).