### PR TITLE
Add light css improvement

### DIFF
--- a/docs-source/_media/theme.css
+++ b/docs-source/_media/theme.css
@@ -702,7 +702,7 @@ body {
 .markdown-section p,
 .markdown-section ul,
 .markdown-section ol {
-    line-height: 1.6rem;
+    line-height: 1.5;
     word-spacing: 0.05rem;
 }
 .markdown-section ul,
@@ -727,15 +727,15 @@ body {
     font-weight: normal;
 }
 .markdown-section code {
-    background-color: #000000;
+    background-color: #390000;
     border-radius: 2px;
-    color: #d60606;
+    color: #fff2f2;
     font-family: 'Roboto Mono', Monaco, courier, monospace;
     font-size: 0.8rem;
     margin: 0 2px;
     padding: 2px 5px;
     white-space: pre-wrap;
-    border: #800000 solid 1px
+    border: #ca0000 solid 1px
 }
 .markdown-section pre {
     -moz-osx-font-smoothing: initial;


### PR DESCRIPTION
Made our docs a little bit easier to read.

Before:
<img width="1117" alt="Screenshot 2021-04-06 at 19 37 36" src="https://user-images.githubusercontent.com/6718144/113762539-96c9a380-9710-11eb-8593-1f2d68a2f7c7.png">

After:
<img width="1146" alt="Screenshot 2021-04-06 at 19 38 46" src="https://user-images.githubusercontent.com/6718144/113762583-a6e18300-9710-11eb-8bc3-adbb3aa8f0c8.png">
