### PR TITLE
docs: Fix CI badge on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Flame Engine Site
 
 <p align="center">
-  <a title="Deploy" href="https://github.com/flame-engine/flame-engine-site/actions?query=workflow%3Agh-pages+branch%3Amain"><img src="https://github.com/flame-engine/flame-engine-site/workflows/gh-pages/badge.svg?branch=main&event=push"/></a>
+  <a title="Deploy" href="https://github.com/flame-engine/flame-engine-site/actions/workflows/gh-pages.yml"><img src="https://github.com/flame-engine/flame-engine-site/actions/workflows/gh-pages.yml/badge.svg?branch=main"/></a>
   <a title="Discord" href="https://discord.gg/pxrBmy4"><img src="https://img.shields.io/discord/509714518008528896.svg"/></a>
 </p>
 


### PR DESCRIPTION
CI badge on readme is broken (rendering gray), GitHub probably changed the format at some point.
This new one is copied from the actions page.